### PR TITLE
Added termination clauses for rotate and duplicate with negative input

### DIFF
--- a/src/main/scala/com/rockthejvm/lists/ListProblems.scala
+++ b/src/main/scala/com/rockthejvm/lists/ListProblems.scala
@@ -382,7 +382,7 @@ case class ::[+T](override val head: T, override val tail: RList[T]) extends RLi
       else duplicateTailrec(remaining, currentElement, nDuplications + 1, currentElement :: accumulator)
     }
 
-    duplicateTailrec(this.tail, this.head, 0, RNil)
+    if(k <= 0) RNil else duplicateTailrec(this.tail, this.head, 0, RNil)
   }
 
   // rotate by a number of positions to the left
@@ -419,6 +419,7 @@ case class ::[+T](override val head: T, override val tail: RList[T]) extends RLi
       else rotateTailrec(remaining.tail, rotationsLeft - 1, remaining.head :: buffer)
     }
 
+    assert(assertion = k >= 0, message = "k must be a positive integer")
     rotateTailrec(this, k, RNil)
   }
 


### PR DESCRIPTION
Currently, both rotate and duplicate have unintended behaviour when provided with a negative input.

- Duplicate recurses indefinitely until an OOM error is encountered
- Rotate recurses for a very long time, then returns the list in quite a random state (The counter is decremented until the Int wraps around to a positive int, then decrements to 0 when the list is returned in whichever state it happens to be in.

Currently the behaviour for negative input is: 
duplicate: return RNil
rotate: throw an assertion error.

Happy to discuss what the desired behaviour should be other than the above.